### PR TITLE
ci: [DDS-514] Added Release GitHub workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: ./go.mod
-          cache: true
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,49 +34,49 @@ jobs:
           name: ${{ env.BIN_NAME }}-linux
           path: dist/linux-amd64_linux_amd64_v1/${{ env.BIN_NAME }}
 
-  build-docker:
-    name: "Docker image"
-    runs-on: ubuntu-20.04
-    needs: build-binary
-    env:
-      IMAGE_NAME: ${{ github.repository }}
+  # build-docker:
+  #   name: "Docker image"
+  #   runs-on: ubuntu-20.04
+  #   needs: build-binary
+  #   env:
+  #     IMAGE_NAME: ${{ github.repository }}
 
-    steps:
-      - uses: actions/checkout@v3
+  #   steps:
+  #     - uses: actions/checkout@v3
 
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        id: buildx
-        with:
-          install: true
-          version: latest
+  #     - name: Setup Docker Buildx
+  #       uses: docker/setup-buildx-action@v2
+  #       id: buildx
+  #       with:
+  #         install: true
+  #         version: latest
 
-      - name: Configure Docker image metadata
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            ${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=raw,value=build-latest
-            type=sha,format=long
+  #     - name: Configure Docker image metadata
+  #       id: meta
+  #       uses: docker/metadata-action@v4
+  #       with:
+  #         images: |
+  #           ${{ env.IMAGE_NAME }}
+  #         tags: |
+  #           type=ref,event=branch
+  #           type=raw,value=build-latest
+  #           type=sha,format=long
 
-      - name: Build image
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          file: docker/Dockerfile
-          platforms: linux/amd64
-          load: true
-          target: runner
-          tags: ${{ steps.meta.outputs.tags }}
-          outputs: type=docker,dest=/tmp/cheqd-node-build.tar
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+  #     - name: Build image
+  #       uses: docker/build-push-action@v4
+  #       with:
+  #         context: .
+  #         file: docker/Dockerfile
+  #         platforms: linux/amd64
+  #         load: true
+  #         target: runner
+  #         tags: ${{ steps.meta.outputs.tags }}
+  #         outputs: type=docker,dest=/tmp/cheqd-node-build.tar
+  #         cache-from: type=gha
+  #         cache-to: type=gha,mode=min
 
-      - name: Upload Docker build image
-        uses: actions/upload-artifact@v3
-        with:
-          name: cheqd-node-build.tar
-          path: /tmp/cheqd-node-build.tar
+  #     - name: Upload Docker build image
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: cheqd-node-build.tar
+  #         path: /tmp/cheqd-node-build.tar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,49 +34,49 @@ jobs:
           name: ${{ env.BIN_NAME }}-linux
           path: dist/linux-amd64_linux_amd64_v1/${{ env.BIN_NAME }}
 
-  # build-docker:
-  #   name: "Docker image"
-  #   runs-on: ubuntu-20.04
-  #   needs: build-binary
-  #   env:
-  #     IMAGE_NAME: ${{ github.repository }}
+  build-docker:
+    name: "Docker image"
+    runs-on: ubuntu-20.04
+    needs: build-binary
+    env:
+      IMAGE_NAME: ${{ github.repository }}
 
-  #   steps:
-  #     - uses: actions/checkout@v3
+    steps:
+      - uses: actions/checkout@v3
 
-  #     - name: Setup Docker Buildx
-  #       uses: docker/setup-buildx-action@v2
-  #       id: buildx
-  #       with:
-  #         install: true
-  #         version: latest
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        id: buildx
+        with:
+          install: true
+          version: latest
 
-  #     - name: Configure Docker image metadata
-  #       id: meta
-  #       uses: docker/metadata-action@v4
-  #       with:
-  #         images: |
-  #           ${{ env.IMAGE_NAME }}
-  #         tags: |
-  #           type=ref,event=branch
-  #           type=raw,value=build-latest
-  #           type=sha,format=long
+      - name: Configure Docker image metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=raw,value=build-latest
+            type=sha,format=long
 
-  #     - name: Build image
-  #       uses: docker/build-push-action@v4
-  #       with:
-  #         context: .
-  #         file: docker/Dockerfile
-  #         platforms: linux/amd64
-  #         load: true
-  #         target: runner
-  #         tags: ${{ steps.meta.outputs.tags }}
-  #         outputs: type=docker,dest=/tmp/cheqd-node-build.tar
-  #         cache-from: type=gha
-  #         cache-to: type=gha,mode=min
+      - name: Build image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64
+          load: true
+          target: runner
+          tags: ${{ steps.meta.outputs.tags }}
+          outputs: type=docker,dest=/tmp/cheqd-node-build.tar
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
 
-  #     - name: Upload Docker build image
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: cheqd-node-build.tar
-  #         path: /tmp/cheqd-node-build.tar
+      - name: Upload Docker build image
+        uses: actions/upload-artifact@v3
+        with:
+          name: cheqd-node-build.tar
+          path: /tmp/cheqd-node-build.tar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,16 +5,17 @@ defaults:
   run:
     shell: bash
 
+env:
+  BIN_NAME: cheqd-noded
 
 jobs:
-
   build-binary:
     name: "Node binary"
     runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3
-      
+
       - uses: actions/setup-go@v4
         with:
           go-version-file: ./go.mod
@@ -30,8 +31,8 @@ jobs:
       - name: Store artifact
         uses: actions/upload-artifact@v3
         with:
-          name: cheqd-noded
-          path: dist/linux-amd64_linux_amd64_v1/cheqd-noded
+          name: ${{ env.BIN_NAME }}-linux
+          path: dist/linux-amd64_linux_amd64_v1/${{ env.BIN_NAME }}
 
   build-docker:
     name: "Docker image"

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,12 +1,10 @@
 name: "Workflow Dispatch"
 on: push
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-
 jobs:
-
   call-lint:
     name: "Lint"
     uses: ./.github/workflows/lint.yml
@@ -14,11 +12,19 @@ jobs:
 
   call-build:
     name: "Build"
+    needs: call-lint
     uses: ./.github/workflows/build.yml
     secrets: inherit
-  
+
   call-test:
     name: "Tests"
-    needs: [ call-lint, call-build ]
+    needs: call-build
     uses: ./.github/workflows/test.yml
+    secrets: inherit
+
+  call-release:
+    name: "Release"
+    needs: call-test
+    if: ${{ github.ref_type == 'tag' }}
+    uses: ./.github/workflows/release.yml
     secrets: inherit

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -5,26 +5,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  call-lint:
-    name: "Lint"
-    uses: ./.github/workflows/lint.yml
-    secrets: inherit
+  # call-lint:
+  #   name: "Lint"
+  #   uses: ./.github/workflows/lint.yml
+  #   secrets: inherit
 
   call-build:
     name: "Build"
-    needs: call-lint
+    # needs: call-lint
     uses: ./.github/workflows/build.yml
     secrets: inherit
 
-  call-test:
-    name: "Tests"
-    needs: call-build
-    uses: ./.github/workflows/test.yml
-    secrets: inherit
+  # call-test:
+  #   name: "Tests"
+  #   needs: call-build
+  #   uses: ./.github/workflows/test.yml
+  #   secrets: inherit
 
   call-release:
     name: "Release"
-    needs: call-test
+    # needs: call-test
+    needs: call-build
     if: ${{ github.ref_type == 'tag' }}
     uses: ./.github/workflows/release.yml
     secrets: inherit

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -5,27 +5,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # call-lint:
-  #   name: "Lint"
-  #   uses: ./.github/workflows/lint.yml
-  #   secrets: inherit
+  call-lint:
+    name: "Lint"
+    uses: ./.github/workflows/lint.yml
+    secrets: inherit
 
   call-build:
     name: "Build"
-    # needs: call-lint
+    needs: call-lint
     uses: ./.github/workflows/build.yml
     secrets: inherit
 
-  # call-test:
-  #   name: "Tests"
-  #   needs: call-build
-  #   uses: ./.github/workflows/test.yml
-  #   secrets: inherit
+  call-test:
+    name: "Tests"
+    needs: call-build
+    uses: ./.github/workflows/test.yml
+    secrets: inherit
 
   call-release:
     name: "Release"
-    # needs: call-test
-    needs: call-build
+    needs: call-test
     if: ${{ github.ref_type == 'tag' }}
     uses: ./.github/workflows/release.yml
     secrets: inherit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,38 +5,36 @@ defaults:
   run:
     shell: bash
 
-
 jobs:
-
   sh-euox-pipefail-check:
     name: "Shell pipefail check"
     runs-on: ubuntu-20.04
-    
+
     steps:
       - uses: actions/checkout@v3
 
       - name: Run 'set -euox pipefail' check
         run: bash ./.github/scripts/ensure_set_euox_pipefail.sh
-  
+
   md-link-check:
     name: "Broken Markdown links"
     runs-on: ubuntu-20.04
-    
+
     steps:
       - uses: actions/checkout@v3
 
       - name: Run Markdown link check
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
-          config-file: '.github/linters/mlc_config.json'
-          use-quiet-mode: 'yes'
-  
+          config-file: ".github/linters/mlc_config.json"
+          use-quiet-mode: "yes"
+
   go-lint:
     # We can't use VALIDATE_GO from super linter because of this issue:
     # https://github.com/github/super-linter/issues/143
     name: "Golang"
     runs-on: ubuntu-20.04
-    
+
     steps:
       - uses: actions/checkout@v3
 
@@ -44,7 +42,7 @@ jobs:
         with:
           go-version-file: ./go.mod
           cache: true
-      
+
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -56,12 +54,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      
+
       # Install the `buf` CLI
       - uses: bufbuild/buf-setup-action@v1.21.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      
+
       # Lint
       - uses: bufbuild/buf-lint-action@v1
         with:
@@ -69,36 +67,36 @@ jobs:
 
       # Breaking change detection
       # - uses: bufbuild/buf-breaking-action@v1
-        # with:
-          # input: proto
-          # against: 'https://github.com/canow-co/cheqd-node.git#branch=develop,ref=HEAD~1,subdir=proto'
+      #   with:
+      #     input: proto
+      #     against: 'https://github.com/canow-co/cheqd-node.git#branch=develop,ref=HEAD~1,subdir=proto'
 
   super-lint:
     name: "Super Linter"
     runs-on: ubuntu-20.04
-    
+
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0 # Required to fetch version
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Required to fetch version
 
-    - name: Run Super Linter
-      uses: github/super-linter/slim@v5
-      env:
-        IGNORE_GITIGNORED_FILES: true
-        DEFAULT_BRANCH: main
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        LOG_LEVEL: WARN
-        VALIDATE_ALL_CODEBASE: false
-        MULTI_STATUS: true
+      - name: Run Super Linter
+        uses: github/super-linter/slim@v5
+        env:
+          IGNORE_GITIGNORED_FILES: true
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LOG_LEVEL: WARN
+          VALIDATE_ALL_CODEBASE: false
+          MULTI_STATUS: true
 
-        VALIDATE_BASH: true
-        VALIDATE_DOCKERFILE_HADOLINT: true
-        VALIDATE_ENV: true
-        VALIDATE_GITHUB_ACTIONS: true
-        VALIDATE_JSON: true
-        VALIDATE_MARKDOWN: true
-        VALIDATE_OPENAPI: true
-        VALIDATE_PYTHON_PYLINT: true
-        VALIDATE_XML: true
-        VALIDATE_YAML: true
+          VALIDATE_BASH: true
+          VALIDATE_DOCKERFILE_HADOLINT: true
+          VALIDATE_ENV: true
+          VALIDATE_GITHUB_ACTIONS: true
+          VALIDATE_JSON: true
+          VALIDATE_MARKDOWN: true
+          VALIDATE_OPENAPI: true
+          VALIDATE_PYTHON_PYLINT: true
+          VALIDATE_XML: true
+          VALIDATE_YAML: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: ./go.mod
-          cache: true
+          cache: false # to bypass https://github.com/golangci/golangci-lint-action/issues/23
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,13 +20,15 @@ jobs:
   lint-pr:
     name: "PR format check"
     runs-on: ubuntu-latest
-    
+    permissions:
+      pull-requests: read
+
     steps:
       - uses: actions/checkout@v3
 
       - uses: amannn/action-semantic-pull-request@v5.2.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           # Configure which types are allowed (newline delimited).
           # Default: https://github.com/commitizen/conventional-commit-types

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,109 @@
+name: "Release"
+on:
+  workflow_call:
+defaults:
+  run:
+    shell: bash
+
+env:
+  APP_NAME: ${{ github.repository }}
+  BIN_NAME: cheqd-noded
+
+jobs:
+  release-binary:
+    name: "Node binary"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      RELEASE_VERSION: ${{ steps.set-version.outputs.RELEASE_VERSION }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # to fetch all history
+
+      - name: Set release version number
+        id: set-version
+        run: |
+          RELEASE_VERSION=$( git describe --tags "${{ github.sha }}")
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download binary artifact
+        uses: actions/download-artifact@v3
+        id: download
+        with:
+          path: release/
+
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: release
+
+      - name: Archive application binary
+        run: |
+          tar czf release/${{ env.APP_NAME }}-${{ steps.set-version.outputs.RELEASE_VERSION }}-linux.tar.gz LICENSE README.md -C release/${{ env.BIN_NAME }}-linux ${{ env.BIN_NAME }}
+        shell: bash
+
+      - name: Publish the Release
+        uses: softprops/action-gh-release@v1
+        with:
+          prerelease: true
+          tag_name: ${{ steps.set-version.outputs.RELEASE_VERSION }}
+          target_commitish: ${{ github.sha }}
+          files: release/*
+          generate_release_notes: true
+
+  release-docker:
+    name: "Docker image"
+    needs: release-binary
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE_NAME: ${{ github.repository }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        id: buildx
+        with:
+          version: latest
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Docker image metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=auto
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.release-binary.outputs.RELEASE_VERSION }}
+            type=raw,value=production-latest
+            type=sha,format=long
+          labels: |
+            org.opencontainers.image.vendor="Canow"
+            org.opencontainers.image.created={{date 'dddd, MMMM Do YYYY, h:mm:ss a'}}
+          #   org.opencontainers.image.documentation=""
+
+      - name: Build and push image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=min

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ defaults:
     shell: bash
 
 env:
-  APP_NAME: ${{ github.repository }}
   BIN_NAME: cheqd-noded
 
 jobs:
@@ -41,7 +40,7 @@ jobs:
 
       - name: Archive application binary
         run: |
-          tar czf release/${{ env.APP_NAME }}-${{ steps.set-version.outputs.RELEASE_VERSION }}-linux.tar.gz LICENSE README.md -C release/${{ env.BIN_NAME }}-linux ${{ env.BIN_NAME }}
+          tar czf release/cheqd-node-${{ steps.set-version.outputs.RELEASE_VERSION }}-linux.tar.gz LICENSE README.md -C release/${{ env.BIN_NAME }}-linux ${{ env.BIN_NAME }}
         shell: bash
 
       - name: Publish the Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ permissions:
   checks: write
 
 jobs:
-
   unit-tests:
     name: "Unit Tests"
     runs-on: ubuntu-20.04
@@ -50,7 +49,7 @@ jobs:
         uses: actions/download-artifact@v3
         id: download
         with:
-          name: cheqd-noded
+          name: cheqd-noded-linux
           path: ${{ env.RUNNER_BIN_DIR }}
 
       - name: Restore binary permissions
@@ -133,8 +132,8 @@ jobs:
 
       - uses: mikepenz/action-junit-report@v3
         with:
-          report_paths: 'report.xml'
+          report_paths: "report.xml"
           check_name: ""
-          suite_regex: '*'
+          suite_regex: "*"
           include_passed: true
           detailed_summary: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: ./go.mod
-          cache: true
 
       - name: Install ginkgo
         working-directory: ./..
@@ -85,7 +84,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: ./go.mod
-          cache: true
 
       - name: Install ginkgo
         working-directory: ./..


### PR DESCRIPTION
- Added `Release` GitHub workflow.
- Made `call-build` job dependent on `call-lint` job.
- Disabled caching in `actions/setup-go` before `golangci/golangci-lint-action` to avoid https://github.com/golangci/golangci-lint-action/issues/23.
- Made some minor corrections.